### PR TITLE
also support GL_ARB_multitexture for multitexturing

### DIFF
--- a/WinQuake/gl_draw.c
+++ b/WinQuake/gl_draw.c
@@ -1281,17 +1281,17 @@ int GL_LoadPicTexture (qpic_t *pic)
 }
 
 /****************************************/
-
-static GLenum oldtarget = TEXTURE0_SGIS;
+static GLenum oldtarget = -1;
 
 void GL_SelectTexture (GLenum target) 
 {
+	oldtarget = oldtarget == -1 ? target : oldtarget;
 	if (!gl_mtexable)
 		return;
-	qglSelectTextureSGIS(target);
+	qglSelectTexture(target);
 	if (target == oldtarget) 
 		return;
-	cnttextures[oldtarget-TEXTURE0_SGIS] = currenttexture;
-	currenttexture = cnttextures[target-TEXTURE0_SGIS];
+	cnttextures[oldtarget-qglMtex0] = currenttexture;
+	currenttexture = cnttextures[target-qglMtex0];
 	oldtarget = target;
 }

--- a/WinQuake/gl_draw.c
+++ b/WinQuake/gl_draw.c
@@ -1291,7 +1291,7 @@ void GL_SelectTexture (GLenum target)
 	qglSelectTexture(target);
 	if (target == oldtarget) 
 		return;
-	cnttextures[oldtarget-qglMtex0] = currenttexture;
-	currenttexture = cnttextures[target-qglMtex0];
+	cnttextures[oldtarget-qglMTex0] = currenttexture;
+	currenttexture = cnttextures[target-qglMTex0];
 	oldtarget = target;
 }

--- a/WinQuake/gl_rsurf.c
+++ b/WinQuake/gl_rsurf.c
@@ -279,8 +279,8 @@ void DrawGLWaterPolyLightmap (glpoly_t *p);
 lpMTexFUNC qglMTexCoord2f = NULL;
 lpSelTexFUNC qglSelectTexture = NULL;
 
-GLenum qglMtex0;
-GLenum qglMtex1;
+GLenum qglMTex0;
+GLenum qglMTex1;
 
 qboolean mtexenabled = false;
 
@@ -290,7 +290,7 @@ void GL_DisableMultitexture(void)
 {
 	if (mtexenabled) {
 		glDisable(GL_TEXTURE_2D);
-		GL_SelectTexture(qglMtex0);
+		GL_SelectTexture(qglMTex0);
 		mtexenabled = false;
 	}
 }
@@ -298,7 +298,7 @@ void GL_DisableMultitexture(void)
 void GL_EnableMultitexture(void) 
 {
 	if (gl_mtexable) {
-		GL_SelectTexture(qglMtex1);
+		GL_SelectTexture(qglMTex1);
 		glEnable(GL_TEXTURE_2D);
 		mtexenabled = true;
 	}
@@ -433,7 +433,7 @@ void R_DrawSequentialPoly (msurface_t *s)
 
 			t = R_TextureAnimation (s->texinfo->texture);
 			// Binds world to texture env 0
-			GL_SelectTexture(qglMtex0);
+			GL_SelectTexture(qglMTex0);
 			GL_Bind (t->gl_texturenum);
 			glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 			// Binds lightmap to texenv 1
@@ -457,8 +457,8 @@ void R_DrawSequentialPoly (msurface_t *s)
 			v = p->verts[0];
 			for (i=0 ; i<p->numverts ; i++, v+= VERTEXSIZE)
 			{
-				qglMTexCoord2f (qglMtex0, v[3], v[4]);
-				qglMTexCoord2f (qglMtex1, v[5], v[6]);
+				qglMTexCoord2f (qglMTex0, v[3], v[4]);
+				qglMTexCoord2f (qglMTex1, v[5], v[6]);
 				glVertex3fv (v);
 			}
 			glEnd ();
@@ -536,7 +536,7 @@ void R_DrawSequentialPoly (msurface_t *s)
 		p = s->polys;
 
 		t = R_TextureAnimation (s->texinfo->texture);
-		GL_SelectTexture(qglMtex0);
+		GL_SelectTexture(qglMTex0);
 		GL_Bind (t->gl_texturenum);
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 		GL_EnableMultitexture();
@@ -559,8 +559,8 @@ void R_DrawSequentialPoly (msurface_t *s)
 		v = p->verts[0];
 		for (i=0 ; i<p->numverts ; i++, v+= VERTEXSIZE)
 		{
-			qglMTexCoord2f (qglMtex0, v[3], v[4]);
-			qglMTexCoord2f (qglMtex1, v[5], v[6]);
+			qglMTexCoord2f (qglMTex0, v[3], v[4]);
+			qglMTexCoord2f (qglMTex1, v[5], v[6]);
 
 			nv[0] = v[0] + 8*sin(v[1]*0.05+realtime)*sin(v[2]*0.05+realtime);
 			nv[1] = v[1] + 8*sin(v[0]*0.05+realtime)*sin(v[2]*0.05+realtime);
@@ -1668,7 +1668,7 @@ void GL_BuildLightmaps (void)
 	}
 
  	if (!gl_texsort.value)
-		GL_SelectTexture(qglMtex1);
+		GL_SelectTexture(qglMTex1);
 
 	//
 	// upload all lightmaps that were filled
@@ -1691,7 +1691,7 @@ void GL_BuildLightmaps (void)
 	}
 
  	if (!gl_texsort.value)
-		GL_SelectTexture(qglMtex0);
+		GL_SelectTexture(qglMTex0);
 
 }
 

--- a/WinQuake/gl_rsurf.c
+++ b/WinQuake/gl_rsurf.c
@@ -276,8 +276,11 @@ extern	float	speedscale;		// for top sky and bottom sky
 void DrawGLWaterPoly (glpoly_t *p);
 void DrawGLWaterPolyLightmap (glpoly_t *p);
 
-lpMTexFUNC qglMTexCoord2fSGIS = NULL;
-lpSelTexFUNC qglSelectTextureSGIS = NULL;
+lpMTexFUNC qglMTexCoord2f = NULL;
+lpSelTexFUNC qglSelectTexture = NULL;
+
+GLenum qglMtex0;
+GLenum qglMtex1;
 
 qboolean mtexenabled = false;
 
@@ -287,7 +290,7 @@ void GL_DisableMultitexture(void)
 {
 	if (mtexenabled) {
 		glDisable(GL_TEXTURE_2D);
-		GL_SelectTexture(TEXTURE0_SGIS);
+		GL_SelectTexture(qglMtex0);
 		mtexenabled = false;
 	}
 }
@@ -295,7 +298,7 @@ void GL_DisableMultitexture(void)
 void GL_EnableMultitexture(void) 
 {
 	if (gl_mtexable) {
-		GL_SelectTexture(TEXTURE1_SGIS);
+		GL_SelectTexture(qglMtex1);
 		glEnable(GL_TEXTURE_2D);
 		mtexenabled = true;
 	}
@@ -430,7 +433,7 @@ void R_DrawSequentialPoly (msurface_t *s)
 
 			t = R_TextureAnimation (s->texinfo->texture);
 			// Binds world to texture env 0
-			GL_SelectTexture(TEXTURE0_SGIS);
+			GL_SelectTexture(qglMtex0);
 			GL_Bind (t->gl_texturenum);
 			glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 			// Binds lightmap to texenv 1
@@ -454,8 +457,8 @@ void R_DrawSequentialPoly (msurface_t *s)
 			v = p->verts[0];
 			for (i=0 ; i<p->numverts ; i++, v+= VERTEXSIZE)
 			{
-				qglMTexCoord2fSGIS (TEXTURE0_SGIS, v[3], v[4]);
-				qglMTexCoord2fSGIS (TEXTURE1_SGIS, v[5], v[6]);
+				qglMTexCoord2f (qglMtex0, v[3], v[4]);
+				qglMTexCoord2f (qglMtex1, v[5], v[6]);
 				glVertex3fv (v);
 			}
 			glEnd ();
@@ -533,7 +536,7 @@ void R_DrawSequentialPoly (msurface_t *s)
 		p = s->polys;
 
 		t = R_TextureAnimation (s->texinfo->texture);
-		GL_SelectTexture(TEXTURE0_SGIS);
+		GL_SelectTexture(qglMtex0);
 		GL_Bind (t->gl_texturenum);
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 		GL_EnableMultitexture();
@@ -556,8 +559,8 @@ void R_DrawSequentialPoly (msurface_t *s)
 		v = p->verts[0];
 		for (i=0 ; i<p->numverts ; i++, v+= VERTEXSIZE)
 		{
-			qglMTexCoord2fSGIS (TEXTURE0_SGIS, v[3], v[4]);
-			qglMTexCoord2fSGIS (TEXTURE1_SGIS, v[5], v[6]);
+			qglMTexCoord2f (qglMtex0, v[3], v[4]);
+			qglMTexCoord2f (qglMtex1, v[5], v[6]);
 
 			nv[0] = v[0] + 8*sin(v[1]*0.05+realtime)*sin(v[2]*0.05+realtime);
 			nv[1] = v[1] + 8*sin(v[0]*0.05+realtime)*sin(v[2]*0.05+realtime);
@@ -1665,7 +1668,7 @@ void GL_BuildLightmaps (void)
 	}
 
  	if (!gl_texsort.value)
- 		GL_SelectTexture(TEXTURE1_SGIS);
+		GL_SelectTexture(qglMtex1);
 
 	//
 	// upload all lightmaps that were filled
@@ -1688,7 +1691,7 @@ void GL_BuildLightmaps (void)
 	}
 
  	if (!gl_texsort.value)
- 		GL_SelectTexture(TEXTURE0_SGIS);
+		GL_SelectTexture(qglMtex0);
 
 }
 

--- a/WinQuake/gl_vidlinux.c
+++ b/WinQuake/gl_vidlinux.c
@@ -280,10 +280,10 @@ void CheckMultiTextureExtensions(void)
 			return;
 		}
 
-		qglMTexCoord2fSGIS = (void *) dlsym(prjobj, "glMTexCoord2fSGIS");
-		qglSelectTextureSGIS = (void *) dlsym(prjobj, "glSelectTextureSGIS");
+		qglMTexCoord2f = (void *) dlsym(prjobj, "glMTexCoord2fSGIS");
+		qglSelectTexture = (void *) dlsym(prjobj, "glSelectTextureSGIS");
 
-		if (qglMTexCoord2fSGIS && qglSelectTextureSGIS) {
+		if (qglMTexCoord2f && qglSelectTexture) {
 			Con_Printf("Multitexture extensions found.\n");
 			gl_mtexable = true;
 		} else

--- a/WinQuake/gl_vidlinuxglx.c
+++ b/WinQuake/gl_vidlinuxglx.c
@@ -562,13 +562,13 @@ void CheckMultiTextureExtensions(void)
 		if (strstr(gl_extensions, "GL_SGIS_multitexture ")) {
 			qglMTexCoord2f = (void *) dlsym(prjobj, "glMTexCoord2fSGIS");
 			qglSelectTexture = (void *) dlsym(prjobj, "glSelectTextureSGIS");
-			qglMtex0 = TEXTURE0_SGIS;
-			qglMtex1 = TEXTURE1_SGIS;
+			qglMTex0 = TEXTURE0_SGIS;
+			qglMTex1 = TEXTURE1_SGIS;
 		} else {
 			qglMTexCoord2f = (void *) dlsym(prjobj, "glMultiTexCoord2fARB");
 			qglSelectTexture = (void *) dlsym(prjobj, "glActiveTextureARB");
-			qglMtex0 = TEXTURE0_ARB;
-			qglMtex1 = TEXTURE1_ARB;
+			qglMTex0 = TEXTURE0_ARB;
+			qglMTex1 = TEXTURE1_ARB;
 		}
 
 		if (qglMTexCoord2f && qglSelectTexture) {

--- a/WinQuake/gl_vidlinuxglx.c
+++ b/WinQuake/gl_vidlinuxglx.c
@@ -78,6 +78,12 @@ static int default_dotclock_vidmode;
 static int num_vidmodes;
 static qboolean vidmode_active = false;
 
+// Multitexture
+#define    TEXTURE0_SGIS				0x835E
+#define    TEXTURE1_SGIS				0x835F
+#define    TEXTURE0_ARB					0x84C0
+#define    TEXTURE1_ARB					0x84C1
+
 /*-----------------------------------------------------------------------*/
 
 //int		texture_mode = GL_NEAREST;
@@ -543,22 +549,35 @@ void CheckMultiTextureExtensions(void)
 {
 	void *prjobj;
 
-	if (strstr(gl_extensions, "GL_SGIS_multitexture ") && !COM_CheckParm("-nomtex")) {
-		Con_Printf("Found GL_SGIS_multitexture...\n");
+	qboolean gl_mtex_avail = strstr(gl_extensions, "GL_SGIS_multitexture ") || strstr(gl_extensions, "GL_ARB_multitexture ");
+
+	if (gl_mtex_avail && !COM_CheckParm("-nomtex")) {
+		Con_Printf("Found GL_multitexture...\n");
 
 		if ((prjobj = dlopen(NULL, RTLD_LAZY)) == NULL) {
 			Con_Printf("Unable to open symbol list for main program.\n");
 			return;
 		}
 
-		qglMTexCoord2fSGIS = (void *) dlsym(prjobj, "glMTexCoord2fSGIS");
-		qglSelectTextureSGIS = (void *) dlsym(prjobj, "glSelectTextureSGIS");
+		if (strstr(gl_extensions, "GL_SGIS_multitexture ")) {
+			qglMTexCoord2f = (void *) dlsym(prjobj, "glMTexCoord2fSGIS");
+			qglSelectTexture = (void *) dlsym(prjobj, "glSelectTextureSGIS");
+			qglMtex0 = TEXTURE0_SGIS;
+			qglMtex1 = TEXTURE1_SGIS;
+		} else {
+			qglMTexCoord2f = (void *) dlsym(prjobj, "glMultiTexCoord2fARB");
+			qglSelectTexture = (void *) dlsym(prjobj, "glActiveTextureARB");
+			qglMtex0 = TEXTURE0_ARB;
+			qglMtex1 = TEXTURE1_ARB;
+		}
 
-		if (qglMTexCoord2fSGIS && qglSelectTextureSGIS) {
+		if (qglMTexCoord2f && qglSelectTexture) {
 			Con_Printf("Multitexture extensions found.\n");
 			gl_mtexable = true;
-		} else
+		} else {
+			printf("%p %p\n", qglMTexCoord2f, qglSelectTexture);
 			Con_Printf("Symbol not found, disabled.\n");
+		}
 
 		dlclose(prjobj);
 	}

--- a/WinQuake/gl_vidnt.c
+++ b/WinQuake/gl_vidnt.c
@@ -579,8 +579,8 @@ void CheckMultiTextureExtensions(void)
 {
 	if (strstr(gl_extensions, "GL_SGIS_multitexture ") && !COM_CheckParm("-nomtex")) {
 		Con_Printf("Multitexture extensions found.\n");
-		qglMTexCoord2fSGIS = (void *) wglGetProcAddress("glMTexCoord2fSGIS");
-		qglSelectTextureSGIS = (void *) wglGetProcAddress("glSelectTextureSGIS");
+		qglMTexCoord2f= (void *) wglGetProcAddress("glMTexCoord2fSGIS");
+		qglSelectTexture = (void *) wglGetProcAddress("glSelectTextureSGIS");
 		gl_mtexable = true;
 	}
 }

--- a/WinQuake/glquake.h
+++ b/WinQuake/glquake.h
@@ -232,18 +232,17 @@ extern	const char *gl_extensions;
 void R_TranslatePlayerSkin (int playernum);
 void GL_Bind (int texnum);
 
-// Multitexture
-#define    TEXTURE0_SGIS				0x835E
-#define    TEXTURE1_SGIS				0x835F
-
 #ifndef _WIN32
 #define APIENTRY /* */
 #endif
 
 typedef void (APIENTRY *lpMTexFUNC) (GLenum, GLfloat, GLfloat);
 typedef void (APIENTRY *lpSelTexFUNC) (GLenum);
-extern lpMTexFUNC qglMTexCoord2fSGIS;
-extern lpSelTexFUNC qglSelectTextureSGIS;
+extern lpMTexFUNC qglMTexCoord2f;
+extern lpSelTexFUNC qglSelectTexture;
+
+extern GLenum qglMtex0;
+extern GLenum qglMtex1;
 
 extern qboolean gl_mtexable;
 

--- a/WinQuake/glquake.h
+++ b/WinQuake/glquake.h
@@ -241,8 +241,8 @@ typedef void (APIENTRY *lpSelTexFUNC) (GLenum);
 extern lpMTexFUNC qglMTexCoord2f;
 extern lpSelTexFUNC qglSelectTexture;
 
-extern GLenum qglMtex0;
-extern GLenum qglMtex1;
+extern GLenum qglMTex0;
+extern GLenum qglMTex1;
 
 extern qboolean gl_mtexable;
 


### PR DESCRIPTION
Now both GL_SGIS_multitexture and GL_ARB_multitexture are supported

At the time of release GL_SGIS_multitexture was the multitexturing extension
available.  However GL_ARB_multitexture is the univeral extension, in fact I
don't believe any modern OpenGL implementation supports GL_SGIS_multitexture.

This had to do some minor rework of the multitexturing code to support more
than one implementation.